### PR TITLE
Fixing memory safety issue on empty blocks.

### DIFF
--- a/src/internal/TOCInternal_BlockObject.m
+++ b/src/internal/TOCInternal_BlockObject.m
@@ -13,7 +13,9 @@
     return b;
 }
 -(void)run {
-    block();
+    if (block) {
+        block();
+    }
 }
 -(SEL)runSelector {
     return @selector(run);


### PR DESCRIPTION
From Facebook’s Infer:
```
TOCInternal_BlockObject.m:16: warning: IVAR_NOT_NULL_CHECKED
   Instance variable self -> block is not checked for null, there could
be a null pointer dereference: pointer self->block last accessed on
line 16 could be null and is dereferenced at line 16, column 5
```