### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,6 @@ Development
 
 1. **Get Source Code**: [Clone this git repository to your machine](https://help.github.com/articles/fetching-a-remote).
 
-2. **Get Dependencies**: [Have cocoa pods installed](http://guides.cocoapods.org/using/getting-started.html). Run `pod install` from the project directory.
+2. **Get Dependencies**: [Have CocoaPods installed](http://guides.cocoapods.org/using/getting-started.html). Run `pod install` from the project directory.
 	
 3. **Open Workspace**: Open `CollapsingFutures.xworkspace` with XCode (not the project, the *workspace*). Run tests and confirm that they pass.


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
